### PR TITLE
Fix compilation casting

### DIFF
--- a/lib/src/kdbx_var_dictionary.dart
+++ b/lib/src/kdbx_var_dictionary.dart
@@ -20,37 +20,37 @@ class ValueType<T> {
   final Decoder<T> decoder;
   final Encoder<T>? encoder;
 
-  static final typeUInt32 = ValueType(
+  static final typeUInt32 = ValueType<int>(
     0x04,
     (reader, _) => reader.readUint32(),
     (writer, value) => writer.writeUint32(value, writer._lengthWriter()),
   );
-  static final typeUInt64 = ValueType(
+  static final typeUInt64 = ValueType<int>(
     0x05,
     (reader, _) => reader.readUint64(),
     (writer, value) => writer.writeUint64(value, writer._lengthWriter()),
   );
-  static final typeBool = ValueType(
+  static final typeBool = ValueType<bool>(
     0x08,
     (reader, _) => reader.readUint8() != 0,
     (writer, value) => writer.writeUint8(value ? 1 : 0, writer._lengthWriter()),
   );
-  static final typeInt32 = ValueType(
+  static final typeInt32 = ValueType<int>(
     0x0C,
     (reader, _) => reader.readInt32(),
     (writer, value) => writer.writeInt32(value, writer._lengthWriter()),
   );
-  static final typeInt64 = ValueType(
+  static final typeInt64 = ValueType<int>(
     0x0D,
     (reader, _) => reader.readInt64(),
     (writer, value) => writer.writeInt64(value, writer._lengthWriter()),
   );
-  static final typeString = ValueType(
+  static final typeString = ValueType<String>(
     0x18,
     (reader, length) => reader.readString(length),
     (writer, value) => writer.writeString(value, writer._lengthWriter()),
   );
-  static final typeBytes = ValueType(
+  static final typeBytes = ValueType<Uint8List>(
     0x42,
     (reader, length) => reader.readBytes(length),
     (writer, value) => writer.writeBytes(value, writer._lengthWriter()),


### PR DESCRIPTION
First of all, thanks for the library!

I'm using
Dart SDK version: 2.19.3 (stable) (Tue Feb 28 15:52:19 2023 +0000) on "macos_arm64"

Without it, I'm getting the following errors.

I'm using Apple M1 (arm64).
```
lib/src/kdbx_var_dictionary.dart:56:42: Error: The argument type 'Object?' can't be assigned to the parameter type 'Uint8List'.
   - 'Object' is from 'dart:core'.
   - 'Uint8List' is from 'dart:typed_data'.
      (writer, value) => writer.writeBytes(value, writer._lengthWriter()),
                                           ^
  lib/src/kdbx_var_dictionary.dart:26:43: Error: The argument type 'Object?' can't be assigned to the parameter type 'int'.
   - 'Object' is from 'dart:core'.
      (writer, value) => writer.writeUint32(value, writer._lengthWriter()),
                                            ^
  lib/src/kdbx_var_dictionary.dart:31:43: Error: The argument type 'Object?' can't be assigned to the parameter type 'int'.
   - 'Object' is from 'dart:core'.
      (writer, value) => writer.writeUint64(value, writer._lengthWriter()),
                                            ^
  lib/src/kdbx_var_dictionary.dart:46:42: Error: The argument type 'Object?' can't be assigned to the parameter type 'int'.
   - 'Object' is from 'dart:core'.
      (writer, value) => writer.writeInt64(value, writer._lengthWriter()),
                                           ^
  lib/src/kdbx_var_dictionary.dart:36:42: Error: A value of type 'Object?' can't be assigned to a variable of type 'bool'.
   - 'Object' is from 'dart:core'.
      (writer, value) => writer.writeUint8(value ? 1 : 0, writer._lengthWriter()),
                                           ^
  lib/src/kdbx_var_dictionary.dart:41:42: Error: The argument type 'Object?' can't be assigned to the parameter type 'int'.
   - 'Object' is from 'dart:core'.
      (writer, value) => writer.writeInt32(value, writer._lengthWriter()),
                                           ^
  lib/src/kdbx_var_dictionary.dart:51:43: Error: The argument type 'Object?' can't be assigned to the parameter type 'String'.
   - 'Object' is from 'dart:core'.
      (writer, value) => writer.writeString(value, writer._lengthWriter()),

```