### PR TITLE
Fix typo in merging error message: market -> marked

### DIFF
--- a/lib/src/kdbx_format.dart
+++ b/lib/src/kdbx_format.dart
@@ -427,7 +427,7 @@ class MergeContext implements OverwriteContext {
   void markAsMerged(KdbxObject object) {
     if (merged.containsKey(object.uuid)) {
       throw StateError(
-        'object was already market as merged! ${object.uuid}: $object',
+        'object was already marked as merged! ${object.uuid}: $object',
       );
     }
     merged[object.uuid] = object;


### PR DESCRIPTION
Fixes [issue #321](https://github.com/authpass/authpass/issues/321) in the `authpass` repo.