### PR TITLE
Open a database from the post-KDF transformed key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.5.0
+
+- `TransformedKeyCredentials`: open a file from the post-KDF key, skipping
+  argon2 entirely. Intended for memory constrained callers such as an iOS
+  autofill extension. Export one from `KdbxFile.transformedKeyCredentials`
+  after a read or save.
+- `KdbxFile.kdfFingerprint` to tell whether a stored transformed key still
+  matches a file; a mismatch throws `KdbxTransformedKeyStaleException`.
+- Fix: `generateSalts()` did not actually rotate the kdbx4 kdf salt, so every
+  save reused the salt the file was created with.
+
 ## 2.4.2
 
 - Update dependencies. (archive, pointycastle)

--- a/lib/kdbx.dart
+++ b/lib/kdbx.dart
@@ -2,7 +2,12 @@
 library;
 
 export 'src/credentials/credentials.dart'
-    show Credentials, CredentialsPart, HashCredentials, PasswordCredentials;
+    show
+        Credentials,
+        CredentialsPart,
+        HashCredentials,
+        PasswordCredentials,
+        TransformedKeyCredentials;
 export 'src/credentials/keyfile.dart' show KeyFileComposite, KeyFileCredentials;
 export 'src/crypto/key_encrypter_kdf.dart'
     show KeyEncrypterKdf, KdfType, KdfField;

--- a/lib/src/credentials/credentials.dart
+++ b/lib/src/credentials/credentials.dart
@@ -19,6 +19,13 @@ abstract class Credentials {
 
   factory Credentials.fromHash(Uint8List hash) => HashCredentials(hash);
 
+  /// The composite hash, which is the input to the key derivation function.
+  ///
+  /// May throw [UnsupportedError]: an implementation is allowed to carry the
+  /// KDF *output* instead, and the input cannot be recovered from it. The one
+  /// in this package that does is [TransformedKeyCredentials]. Callers that
+  /// hash, cache or log credentials generically should be prepared for that,
+  /// or check the type first.
   Uint8List getHash();
 }
 
@@ -63,7 +70,23 @@ class TransformedKeyCredentials implements Credentials {
   TransformedKeyCredentials({
     required this.transformedKey,
     required this.kdfFingerprint,
-  });
+  }) {
+    // Checked here rather than on use. A short key throws a RangeError from
+    // inside the key/seed concatenation, and a long one is worse: it derives
+    // the wrong cipher key and surfaces as a decryption failure, which reads
+    // like a wrong password. The assert on the concatenated length is no help
+    // in release builds.
+    if (transformedKey.length != _transformedKeyLength) {
+      throw ArgumentError.value(
+        transformedKey.length,
+        'transformedKey',
+        'A transformed key is the $_transformedKeyLength byte output of the '
+            'key derivation function; got a length of',
+      );
+    }
+  }
+
+  static const _transformedKeyLength = 32;
 
   /// The 32 byte output of the key derivation function.
   final Uint8List transformedKey;

--- a/lib/src/credentials/credentials.dart
+++ b/lib/src/credentials/credentials.dart
@@ -41,3 +41,43 @@ class HashCredentials implements Credentials {
   @override
   Uint8List getHash() => hash;
 }
+
+/// Credentials which carry the key material produced *by* the key derivation
+/// function, instead of the input to it.
+///
+/// Opening or saving a file with these skips the KDF (Argon2 / AES-KDF)
+/// entirely. That makes kdbx usable in memory constrained environments — an
+/// iOS AutoFill extension is capped at roughly 120 MB, well below what Argon2
+/// at common KeePass settings needs.
+///
+/// The key is only valid for the exact KDF parameters it was derived from.
+/// [KdbxHeader.generateSalts] rotates the KDF salt on every save, so a stored
+/// transformed key goes stale as soon as the file is written — by this
+/// application or by any other. [kdfFingerprint] captures the parameters it
+/// belongs to; opening a file whose fingerprint differs throws
+/// [KdbxTransformedKeyStaleException] rather than reporting a wrong password.
+///
+/// Obtain one from [KdbxFile.transformedKeyCredentials] after a regular open
+/// or save. Only KDBX4 files are supported.
+class TransformedKeyCredentials implements Credentials {
+  TransformedKeyCredentials({
+    required this.transformedKey,
+    required this.kdfFingerprint,
+  });
+
+  /// The 32 byte output of the key derivation function.
+  final Uint8List transformedKey;
+
+  /// Fingerprint of the KDF parameters [transformedKey] was derived from,
+  /// as produced by [KdbxFile.kdfFingerprint].
+  final String kdfFingerprint;
+
+  /// Always throws — the composite hash is the KDF *input* and cannot be
+  /// recovered from its output. Nothing on the KDBX4 read or write path needs
+  /// it once a transformed key is available.
+  @override
+  Uint8List getHash() => throw UnsupportedError(
+    'TransformedKeyCredentials carries a post-KDF key, '
+    'the composite hash is not recoverable from it.',
+  );
+}

--- a/lib/src/kdbx_exceptions.dart
+++ b/lib/src/kdbx_exceptions.dart
@@ -2,6 +2,32 @@ class KdbxException implements Exception {}
 
 class KdbxInvalidKeyException implements KdbxException {}
 
+/// Thrown when a [TransformedKeyCredentials] is used against a file whose KDF
+/// parameters have changed since the key was derived — i.e. the file was saved
+/// in the meantime and [KdbxHeader.generateSalts] rotated the salt.
+///
+/// This is not a wrong-credentials error: the user's master password is still
+/// correct, the cached derived key simply expired and has to be re-derived from
+/// the password.
+class KdbxTransformedKeyStaleException implements KdbxException {
+  KdbxTransformedKeyStaleException({
+    required this.expected,
+    required this.actual,
+  });
+
+  /// Fingerprint the transformed key was derived for.
+  final String expected;
+
+  /// Fingerprint of the file being opened.
+  final String actual;
+
+  @override
+  String toString() {
+    return 'KdbxTransformedKeyStaleException{expected: $expected, '
+        'actual: $actual}';
+  }
+}
+
 class KdbxCorruptedFileException implements KdbxException {
   KdbxCorruptedFileException([this.message]);
 

--- a/lib/src/kdbx_file.dart
+++ b/lib/src/kdbx_file.dart
@@ -51,10 +51,51 @@ class KdbxFile {
   final KdbxReadWriteContext ctx;
   Credentials get credentials => _credentials;
   set credentials(Credentials credentials) {
+    // the derived key belongs to the old credentials.
+    _transformedKey = null;
     body.meta.modify(() => _credentials = credentials);
   }
 
   Credentials _credentials;
+
+  Uint8List? _transformedKey;
+
+  /// Records the key derivation output for [transformedKeyCredentials].
+  /// Called by [KdbxFormat] after reading or writing a kdbx4 file.
+  void setTransformedKey(Uint8List transformedKey) {
+    _transformedKey = transformedKey;
+  }
+
+  /// Fingerprint of the key derivation parameters currently in the header.
+  ///
+  /// Changes on every save. Compare against
+  /// [TransformedKeyCredentials.kdfFingerprint] to tell whether a stored
+  /// derived key still applies to this file.
+  String get kdfFingerprint => header.kdfFingerprint;
+
+  /// Credentials which reopen this file without re-running the key derivation
+  /// function, or `null` if the file has not been read or written yet in this
+  /// session (or is not kdbx4).
+  ///
+  /// Intended for environments that cannot afford Argon2 — notably the iOS
+  /// AutoFill extension, whose process memory limit is far below what Argon2
+  /// needs at usual KeePass settings.
+  ///
+  /// Security: this is as good as the master password *for the current
+  /// revision of the file*. It expires on the next save, since
+  /// [KdbxHeader.generateSalts] rotates the KDF salt — which bounds the damage
+  /// a leaked copy can do, unlike the composite hash. Store it accordingly.
+  TransformedKeyCredentials? get transformedKeyCredentials {
+    final transformedKey = _transformedKey;
+    if (transformedKey == null) {
+      return null;
+    }
+    return TransformedKeyCredentials(
+      transformedKey: transformedKey,
+      kdfFingerprint: kdfFingerprint,
+    );
+  }
+
   final KdbxHeader header;
   final KdbxBody body;
   final Set<KdbxObject> dirtyObjects = {};

--- a/lib/src/kdbx_format.dart
+++ b/lib/src/kdbx_format.dart
@@ -552,7 +552,7 @@ class KdbxFormat {
       // the new salt without the original credentials.
       throw KdbxUnsupportedException(
         'Files opened with TransformedKeyCredentials are read-only. '
-        'Reopen with the master password to save.',
+        'Reopen with the original credentials to save.',
       );
     }
     return file.saveLock.synchronized(() async {

--- a/lib/src/kdbx_format.dart
+++ b/lib/src/kdbx_format.dart
@@ -18,6 +18,7 @@ import 'package:kdbx/src/kdbx_deleted_object.dart';
 import 'package:kdbx/src/kdbx_entry.dart';
 import 'package:kdbx/src/kdbx_group.dart';
 import 'package:kdbx/src/kdbx_header.dart';
+import 'package:kdbx/src/kdbx_var_dictionary.dart';
 import 'package:kdbx/src/kdbx_xml.dart';
 import 'package:kdbx/src/utils/byte_utils.dart';
 import 'package:kdbx/src/utils/sequence.dart';
@@ -477,10 +478,14 @@ class MergeContext implements OverwriteContext {
 }
 
 class _KeysV4 {
-  _KeysV4(this.hmacKey, this.cipherKey);
+  _KeysV4(this.hmacKey, this.cipherKey, this.transformedKey);
 
   final Uint8List hmacKey;
   final Uint8List cipherKey;
+
+  /// The KDF output the other two keys were built from. Retained so it can be
+  /// handed out as [KdbxFile.transformedKeyCredentials].
+  final Uint8List transformedKey;
 }
 
 class KdbxFormat {
@@ -542,6 +547,14 @@ class KdbxFormat {
       'Saving ${file.body.rootGroup.uuid} '
       '(locked: ${file.saveLock.locked})',
     );
+    if (file.credentials is TransformedKeyCredentials) {
+      // saving rotates the kdf salt, and a derived key cannot be re-derived for
+      // the new salt without the original credentials.
+      throw KdbxUnsupportedException(
+        'Files opened with TransformedKeyCredentials are read-only. '
+        'Reopen with the master password to save.',
+      );
+    }
     return file.saveLock.synchronized(() async {
       final savedAt = TimeSequence.now();
       final bytes = await _saveSynchronized(file);
@@ -583,6 +596,8 @@ class KdbxFormat {
       final headerHmac = _getHeaderHmac(headerBytes, keys.hmacKey);
       writer.writeBytes(headerHmac.bytes as Uint8List);
       body.writeV4(writer, file, gen, keys);
+      // salts were rotated above, so the derived key is a new one.
+      file.setTransformedKey(keys.transformedKey);
     } else {
       throw UnsupportedError('Unsupported version ${header.version}');
     }
@@ -676,7 +691,7 @@ class KdbxFormat {
         credentials,
         header,
         _loadXml(context, header, xml),
-      );
+      )..setTransformedKey(keys.transformedKey);
     }
     throw StateError('Kdbx4 without compression is not yet supported.');
   }
@@ -802,10 +817,7 @@ class KdbxFormat {
       throw const FormatException('Master seed must be 32 bytes.');
     }
 
-    final credentialHash = credentials.getHash();
-    final key = await KeyEncrypterKdf(
-      argon2,
-    ).encrypt(credentialHash, kdfParameters);
+    final key = await _transformKeyV4(header, kdfParameters, credentials);
 
     //    final keyWithSeed = Uint8List(65);
     //    keyWithSeed.replaceRange(0, masterSeed.length, masterSeed);
@@ -817,7 +829,29 @@ class KdbxFormat {
     final cipher = crypto.sha256.convert(keyWithSeed.sublist(0, 64));
     final hmacKey = crypto.sha512.convert(keyWithSeed);
 
-    return _KeysV4(hmacKey.bytes as Uint8List, cipher.bytes as Uint8List);
+    return _KeysV4(hmacKey.bytes as Uint8List, cipher.bytes as Uint8List, key);
+  }
+
+  /// Runs the key derivation function over [credentials], or skips it when the
+  /// caller already supplied the derived key via [TransformedKeyCredentials].
+  Future<Uint8List> _transformKeyV4(
+    KdbxHeader header,
+    VarDictionary kdfParameters,
+    Credentials credentials,
+  ) async {
+    if (credentials is TransformedKeyCredentials) {
+      final actual = header.kdfFingerprint;
+      if (credentials.kdfFingerprint != actual) {
+        throw KdbxTransformedKeyStaleException(
+          expected: credentials.kdfFingerprint,
+          actual: actual,
+        );
+      }
+      return credentials.transformedKey;
+    }
+    return await KeyEncrypterKdf(
+      argon2,
+    ).encrypt(credentials.getHash(), kdfParameters);
   }
 
   ProtectedSaltGenerator _createProtectedSaltGenerator(KdbxHeader header) {

--- a/lib/src/kdbx_header.dart
+++ b/lib/src/kdbx_header.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart' as crypto;
@@ -583,6 +584,25 @@ class KdbxHeader {
   VarDictionary get readKdfParameters => VarDictionary.read(
     ReaderHelper(fields[HeaderFields.KdfParameters]!.bytes),
   );
+
+  /// Fingerprint of everything the key derivation function depends on — the
+  /// KDF uuid, its salt, and its cost parameters.
+  ///
+  /// Two headers with the same fingerprint derive the same transformed key from
+  /// the same credentials, which is what makes a cached
+  /// [TransformedKeyCredentials] safe to reuse. The KDF parameters are stored
+  /// unencrypted in the file header, so this reveals nothing secret.
+  ///
+  /// Only meaningful for KDBX4; throws [KdbxUnsupportedException] otherwise.
+  String get kdfFingerprint {
+    if (version.major != KdbxVersion.V4.major) {
+      throw KdbxUnsupportedException(
+        'kdf fingerprints are only supported for kdbx4 (got $version)',
+      );
+    }
+    final kdfParameters = fields[HeaderFields.KdfParameters]!.bytes;
+    return base64.encode(crypto.sha256.convert(kdfParameters).bytes);
+  }
 
   int get v3KdfTransformRounds =>
       ReaderHelper.singleUint64(fields[HeaderFields.TransformRounds]!.bytes);

--- a/lib/src/kdbx_header.dart
+++ b/lib/src/kdbx_header.dart
@@ -269,11 +269,14 @@ class KdbxHeader {
         InnerHeaderFields.InnerRandomStreamKey,
         ByteUtils.randomBytes(64),
       );
+      // readKdfParameters decodes into a fresh VarDictionary, so the new salt
+      // has to be encoded back into the header field.
       final kdfParameters = readKdfParameters;
       KdfField.salt.write(
         kdfParameters,
         ByteUtils.randomBytes(Consts.DefaultKdfSaltLength),
       );
+      writeKdfParameters(kdfParameters);
       //         var ivLength = this.dataCipherUuid.toString() === Consts.CipherId.ChaCha20 ? 12 : 16;
       //        this.encryptionIV = Random.getBytes(ivLength);
       final cipher = this.cipher;

--- a/lib/src/kdbx_var_dictionary.dart
+++ b/lib/src/kdbx_var_dictionary.dart
@@ -89,8 +89,7 @@ class VarDictionaryItem<T> {
 
 class VarDictionary {
   VarDictionary(List<VarDictionaryItem<dynamic>> items)
-    : _items = items,
-      _dict = Map.fromEntries(items.map((item) => MapEntry(item._key, item)));
+    : _dict = Map.fromEntries(items.map((item) => MapEntry(item._key, item)));
 
   factory VarDictionary.read(ReaderHelper reader) {
     final items = <VarDictionaryItem<dynamic>>[];
@@ -110,8 +109,12 @@ class VarDictionary {
   }
 
   static const DEFAULT_VERSION = 0x0100;
-  final List<VarDictionaryItem<dynamic>> _items;
+
+  /// Insertion ordered, so writing back a dictionary which was read from a
+  /// file keeps the original field order. [set] replaces in place.
   final Map<String, VarDictionaryItem<dynamic>> _dict;
+
+  Iterable<VarDictionaryItem<dynamic>> get _items => _dict.values;
 
   Uint8List write() {
     final writer = WriterHelper();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kdbx
 description: KeepassX format implementation in pure dart. (kdbx 3.x and 4.x support).
-version: 2.4.2
+version: 2.5.0
 homepage: https://github.com/authpass/kdbx.dart
 
 environment:
@@ -33,3 +33,9 @@ dev_dependencies:
   flutter_lints: '>=2.0.0 <7.0.0'
   test: '>=1.6.0 <2.0.0'
   fake_async: ^1.2.0
+
+# The passkey attribute tests use a PEM shaped placeholder on purpose — that is
+# the format KeePassXC writes — and pub's leak detector cannot tell it from a
+# real key. It decodes to nothing.
+false_secrets:
+  - /test/kpex_custom_strings_test.dart

--- a/test/kpex_custom_strings_test.dart
+++ b/test/kpex_custom_strings_test.dart
@@ -1,0 +1,177 @@
+import 'package:clock/clock.dart';
+import 'package:kdbx/kdbx.dart';
+import 'package:test/test.dart';
+
+import 'internal/test_utils.dart';
+
+/// Attribute names KeePassXC uses to store passkeys, mirrored by Strongbox,
+/// KeePassium and KeePassDX. There is no spec — they are ordinary custom
+/// strings, and every implementation is expected to leave the ones it does not
+/// understand alone.
+///
+/// AuthPass does not read these yet, so what matters here is that editing and
+/// merging a database never drops them: users share vaults with the apps that
+/// do.
+final _relyingParty = KdbxKey('KPEX_PASSKEY_RELYING_PARTY');
+final _username = KdbxKey('KPEX_PASSKEY_USERNAME');
+final _credentialId = KdbxKey('KPEX_PASSKEY_CREDENTIAL_ID');
+final _privateKeyPem = KdbxKey('KPEX_PASSKEY_PRIVATE_KEY_PEM');
+final _userHandle = KdbxKey('KPEX_PASSKEY_USER_HANDLE');
+
+const _pem = '-----BEGIN PRIVATE KEY-----\nMIGHAgEA\n-----END PRIVATE KEY-----';
+
+void main() {
+  TestUtil.setupLogging();
+  final testUtil = TestUtil();
+
+  var now = DateTime.fromMillisecondsSinceEpoch(0);
+  final fakeClock = Clock(() => now);
+  void proceedSeconds(int seconds) {
+    now = now.add(Duration(seconds: seconds));
+  }
+
+  setUp(() {
+    now = DateTime.fromMillisecondsSinceEpoch(0);
+  });
+
+  /// Adds a full set of passkey attributes, protected ones as
+  /// [ProtectedValue] the way KeePassXC writes them.
+  void addPasskey(KdbxEntry entry) {
+    entry.setString(_relyingParty, PlainValue('example.com'));
+    entry.setString(_username, PlainValue('alice@example.com'));
+    entry.setString(_credentialId, ProtectedValue.fromString('Y3JlZC1pZA'));
+    entry.setString(_privateKeyPem, ProtectedValue.fromString(_pem));
+    entry.setString(_userHandle, ProtectedValue.fromString('dXNlci1oYW5kbGU'));
+  }
+
+  void expectPasskey(KdbxEntry entry) {
+    expect(entry.getString(_relyingParty)!.getText(), 'example.com');
+    expect(entry.getString(_username)!.getText(), 'alice@example.com');
+    expect(entry.getString(_credentialId)!.getText(), 'Y3JlZC1pZA');
+    expect(entry.getString(_privateKeyPem)!.getText(), _pem);
+    expect(entry.getString(_userHandle)!.getText(), 'dXNlci1oYW5kbGU');
+  }
+
+  Future<KdbxFile> createFileWithPasskey() async {
+    final file = testUtil.createEmptyFile();
+    final entry = testUtil.createEntry(
+      file,
+      file.body.rootGroup,
+      'alice',
+      'secret',
+    );
+    addPasskey(entry);
+    return await testUtil.saveAndRead(file);
+  }
+
+  group('round trip', () {
+    test('survives save and read', () async {
+      final file = await createFileWithPasskey();
+      expectPasskey(file.body.rootGroup.entries.first);
+    });
+
+    test('keeps protected attributes protected', () async {
+      final file = await createFileWithPasskey();
+      final entry = file.body.rootGroup.entries.first;
+
+      expect(entry.getString(_credentialId), isA<ProtectedValue>());
+      expect(entry.getString(_privateKeyPem), isA<ProtectedValue>());
+      expect(entry.getString(_userHandle), isA<ProtectedValue>());
+      expect(entry.getString(_relyingParty), isA<PlainValue>());
+      expect(entry.getString(_username), isA<PlainValue>());
+    });
+
+    test('survives editing an unrelated field', () async {
+      final file = await createFileWithPasskey();
+      file.body.rootGroup.entries.first.setString(
+        KdbxKeyCommon.USER_NAME,
+        PlainValue('bob'),
+      );
+
+      final saved = await testUtil.saveAndRead(file);
+      final entry = saved.body.rootGroup.entries.first;
+      expect(entry.getString(KdbxKeyCommon.USER_NAME)!.getText(), 'bob');
+      expectPasskey(entry);
+    });
+
+    test('survives in history entries', () async {
+      final file = await createFileWithPasskey();
+      file.body.rootGroup.entries.first.setString(
+        KdbxKeyCommon.USER_NAME,
+        PlainValue('bob'),
+      );
+
+      final saved = await testUtil.saveAndRead(file);
+      final entry = saved.body.rootGroup.entries.first;
+      expect(entry.history, hasLength(1));
+      expectPasskey(entry.history.first);
+    });
+  });
+
+  group('merge', () {
+    test('imports attributes added remotely', () async {
+      await withClock(fakeClock, () async {
+        final file = testUtil.createEmptyFile();
+        testUtil.createEntry(file, file.body.rootGroup, 'alice', 'secret');
+        proceedSeconds(10);
+        final local = await testUtil.saveAndRead(file);
+
+        final remote = await testUtil.saveAndRead(local);
+        proceedSeconds(10);
+        addPasskey(remote.body.rootGroup.entries.first);
+        final remoteSaved = await testUtil.saveAndRead(remote);
+
+        local.merge(remoteSaved);
+        expectPasskey(local.body.rootGroup.entries.first);
+      });
+    });
+
+    test(
+      'keeps local attributes when the remote changed another field',
+      () async {
+        await withClock(fakeClock, () async {
+          final file = await createFileWithPasskey();
+          proceedSeconds(10);
+
+          final remote = await testUtil.saveAndRead(file);
+          proceedSeconds(10);
+          remote.body.rootGroup.entries.first.setString(
+            KdbxKeyCommon.URL,
+            PlainValue('https://example.com'),
+          );
+          final remoteSaved = await testUtil.saveAndRead(remote);
+
+          file.merge(remoteSaved);
+          final entry = file.body.rootGroup.entries.first;
+          expect(
+            entry.getString(KdbxKeyCommon.URL)!.getText(),
+            'https://example.com',
+          );
+          expectPasskey(entry);
+        });
+      },
+    );
+
+    test(
+      'survives a merge into a file which never saw the attributes',
+      () async {
+        await withClock(fakeClock, () async {
+          final file = testUtil.createEmptyFile();
+          testUtil.createEntry(file, file.body.rootGroup, 'alice', 'secret');
+          proceedSeconds(10);
+          final local = await testUtil.saveAndRead(file);
+
+          final remote = await testUtil.saveAndRead(local);
+          proceedSeconds(10);
+          addPasskey(remote.body.rootGroup.entries.first);
+          final remoteSaved = await testUtil.saveAndRead(remote);
+
+          local.merge(remoteSaved);
+          // and make sure they make it back out to disk.
+          final merged = await testUtil.saveAndRead(local);
+          expectPasskey(merged.body.rootGroup.entries.first);
+        });
+      },
+    );
+  });
+}

--- a/test/transformed_key_test.dart
+++ b/test/transformed_key_test.dart
@@ -1,0 +1,182 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:argon2_ffi_base/argon2_ffi_base.dart';
+import 'package:kdbx/kdbx.dart';
+import 'package:test/test.dart';
+
+import 'internal/test_utils.dart';
+
+/// An [Argon2] which blows up if anybody tries to derive a key with it.
+///
+/// Used to prove that opening a file with [TransformedKeyCredentials] never
+/// reaches the key derivation function — that is the whole point of the api,
+/// since Argon2 at usual settings does not fit in an iOS autofill extension.
+class _ExplodingArgon2 extends Argon2 {
+  const _ExplodingArgon2();
+
+  @override
+  bool get isFfi => false;
+
+  @override
+  bool get isImplemented => true;
+
+  @override
+  Uint8List argon2(Argon2Arguments args) =>
+      throw StateError('argon2 must not be called');
+
+  @override
+  Future<Uint8List> argon2Async(Argon2Arguments args) =>
+      throw StateError('argon2 must not be called');
+}
+
+void main() {
+  TestUtil.setupLogging();
+
+  final kdbxFormat = KdbxFormat();
+  final noArgon2Format = KdbxFormat(const _ExplodingArgon2());
+
+  Future<KdbxFile> readKeeweb([Credentials? credentials]) async {
+    final data = await File('test/kdbx4_keeweb.kdbx').readAsBytes();
+    return await kdbxFormat.read(
+      data,
+      credentials ?? Credentials(ProtectedValue.fromString('asdf')),
+    );
+  }
+
+  group('exporting', () {
+    test('is available after reading a kdbx4 file', () async {
+      final file = await readKeeweb();
+      final exported = file.transformedKeyCredentials;
+      expect(exported, isNotNull);
+      expect(exported!.transformedKey, hasLength(32));
+      expect(exported.kdfFingerprint, file.kdfFingerprint);
+    });
+
+    test('is available after saving', () async {
+      final file = TestUtil().createEmptyFile();
+      expect(file.transformedKeyCredentials, isNull);
+      await file.save();
+      expect(file.transformedKeyCredentials, isNotNull);
+    });
+
+    test('rotates on every save, because the kdf salt does', () async {
+      final file = TestUtil().createEmptyFile();
+      await file.save();
+      final first = file.transformedKeyCredentials!;
+      await file.save();
+      final second = file.transformedKeyCredentials!;
+
+      expect(second.kdfFingerprint, isNot(first.kdfFingerprint));
+      expect(second.transformedKey, isNot(first.transformedKey));
+    });
+
+    test('is dropped when the credentials change', () async {
+      final file = await readKeeweb();
+      expect(file.transformedKeyCredentials, isNotNull);
+      file.credentials = Credentials(ProtectedValue.fromString('other'));
+      expect(file.transformedKeyCredentials, isNull);
+    });
+  });
+
+  group('injecting', () {
+    test('opens the file without running argon2', () async {
+      final file = await readKeeweb();
+      final exported = file.transformedKeyCredentials!;
+
+      final data = await File('test/kdbx4_keeweb.kdbx').readAsBytes();
+      final reopened = await noArgon2Format.read(data, exported);
+
+      final entry = reopened.body.rootGroup.entries.first;
+      expect(entry.getString(KdbxKeyCommon.PASSWORD)!.getText(), 'def');
+    });
+
+    test('derives the same keys as the password would', () async {
+      final file = await readKeeweb();
+      final exported = file.transformedKeyCredentials!;
+
+      final data = await File('test/kdbx4_keeweb.kdbx').readAsBytes();
+      final reopened = await noArgon2Format.read(data, exported);
+
+      expect(
+        reopened.transformedKeyCredentials!.transformedKey,
+        exported.transformedKey,
+      );
+    });
+
+    test('rejects a key that does not match the file', () async {
+      final file = await readKeeweb();
+      final wrongKey = TransformedKeyCredentials(
+        transformedKey: Uint8List(32),
+        kdfFingerprint: file.kdfFingerprint,
+      );
+
+      final data = await File('test/kdbx4_keeweb.kdbx').readAsBytes();
+      await expectLater(
+        noArgon2Format.read(data, wrongKey),
+        throwsA(isA<KdbxInvalidKeyException>()),
+      );
+    });
+
+    test('rejects a key derived for different kdf parameters', () async {
+      final file = await readKeeweb();
+      final stale = TransformedKeyCredentials(
+        transformedKey: file.transformedKeyCredentials!.transformedKey,
+        kdfFingerprint: 'not-the-fingerprint-of-this-file',
+      );
+
+      final data = await File('test/kdbx4_keeweb.kdbx').readAsBytes();
+      await expectLater(
+        noArgon2Format.read(data, stale),
+        throwsA(isA<KdbxTransformedKeyStaleException>()),
+      );
+    });
+
+    test('goes stale once the file is saved again', () async {
+      final file = TestUtil().createEmptyFile();
+      final bytes = await file.save();
+      final exported = file.transformedKeyCredentials!;
+
+      // the key still opens the revision it was exported for.
+      await noArgon2Format.read(bytes, exported);
+
+      // ... but not the next one.
+      final resaved = await file.save();
+      await expectLater(
+        noArgon2Format.read(resaved, exported),
+        throwsA(isA<KdbxTransformedKeyStaleException>()),
+      );
+    });
+
+    test('cannot be used to save', () async {
+      final data = await File('test/kdbx4_keeweb.kdbx').readAsBytes();
+      final file = await readKeeweb();
+      final reopened = await noArgon2Format.read(
+        data,
+        file.transformedKeyCredentials!,
+      );
+
+      await expectLater(
+        reopened.save(),
+        throwsA(isA<KdbxUnsupportedException>()),
+      );
+    });
+  });
+
+  group('kdfFingerprint', () {
+    test('is stable for the same file', () async {
+      final first = await readKeeweb();
+      final second = await readKeeweb();
+      expect(second.kdfFingerprint, first.kdfFingerprint);
+    });
+
+    test('differs between files', () async {
+      final keeweb = await readKeeweb();
+      final other = await kdbxFormat.read(
+        await File('test/keepassxcpasswords.kdbx').readAsBytes(),
+        Credentials(ProtectedValue.fromString('asdf')),
+      );
+      expect(other.kdfFingerprint, isNot(keeweb.kdfFingerprint));
+    });
+  });
+}

--- a/test/transformed_key_test.dart
+++ b/test/transformed_key_test.dart
@@ -118,6 +118,21 @@ void main() {
       );
     });
 
+    test('rejects a key of the wrong length', () {
+      // A long key would otherwise derive the wrong cipher key and report
+      // itself as a wrong password, several layers away from the mistake.
+      for (final length in [0, 16, 31, 33, 64]) {
+        expect(
+          () => TransformedKeyCredentials(
+            transformedKey: Uint8List(length),
+            kdfFingerprint: 'whatever',
+          ),
+          throwsA(isA<ArgumentError>()),
+          reason: 'length $length',
+        );
+      }
+    });
+
     test('rejects a key derived for different kdf parameters', () async {
       final file = await readKeeweb();
       final stale = TransformedKeyCredentials(

--- a/test/var_dictionary_test.dart
+++ b/test/var_dictionary_test.dart
@@ -13,12 +13,36 @@ void main() {
   test('write and read var dictionary', () {
     final dict = VarDictionary([
       KdfField.rounds.item(99),
-      KdfField.uuid
-          .item(KeyEncrypterKdf.kdfUuidForType(KdfType.Argon2).toBytes()),
+      KdfField.uuid.item(
+        KeyEncrypterKdf.kdfUuidForType(KdfType.Argon2).toBytes(),
+      ),
     ]);
     final serialized = dict.write();
     _logger.fine('Serialized dictionary: ${ByteUtils.toHexList(serialized)}');
     final r = VarDictionary.read(ReaderHelper(serialized));
+    expect(KdfField.rounds.read(r), 99);
+  });
+
+  test('set is visible after a write/read round trip', () {
+    final dict = VarDictionary([
+      KdfField.rounds.item(99),
+      KdfField.uuid.item(
+        KeyEncrypterKdf.kdfUuidForType(KdfType.Argon2).toBytes(),
+      ),
+    ]);
+    KdfField.rounds.write(dict, 1234);
+
+    final r = VarDictionary.read(ReaderHelper(dict.write()));
+    expect(KdfField.rounds.read(r), 1234);
+    expect(KdfField.uuid.read(r), isNotNull);
+  });
+
+  test('set adds fields which were not present', () {
+    final dict = VarDictionary([KdfField.rounds.item(99)]);
+    KdfField.salt.write(dict, ByteUtils.randomBytes(32));
+
+    final r = VarDictionary.read(ReaderHelper(dict.write()));
+    expect(KdfField.salt.read(r), hasLength(32));
     expect(KdfField.rounds.read(r), 99);
   });
 }


### PR DESCRIPTION
Lets a file be opened from the post-KDF transformed key instead of re-deriving
it, so a caller that cannot afford Argon2 — an app extension with a constrained
memory budget, for instance — can still read a database.

Four commits, each standing on its own:

**`fix: actually rotate the kdf salt on save`** is independent of the rest and
worth looking at first. `generateSalts()` never rotated the KDF salt, because
two things were broken at once: `VarDictionary.set` only updated its lookup map
while `write()` serialized a separate item list, and `generateSalts` never
encoded the modified parameters back into the header field. Every save reused
the salt the file was created with. This affects every consumer, not just the
feature below.

**`feat: export and inject the post-kdf transformed key`** adds
`TransformedKeyCredentials`, exported from a file after any read or save via
`KdbxFile.transformedKeyCredentials`. It is bound to the KDF parameters it was
derived from through `KdbxFile.kdfFingerprint`; opening a file whose salt has
since rotated throws `KdbxTransformedKeyStaleException` rather than looking like
a wrong password. Saving with it is refused outright — the key would be stale
the moment the salt rotates. Tests prove the injected path never touches Argon2,
by reopening with a `KdbxFormat` whose Argon2 implementation throws on call.

**`test: lock in preservation of KPEX_* passkey attributes`** pins existing
behaviour: passkey attributes already round-tripped, and now stay that way
through edits, history and all three merge directions.

**`release 2.5.0`** is the version bump and changelog.

One design point worth your call: `TransformedKeyCredentials.getHash()` throws
`UnsupportedError`, since the composite hash is the KDF *input* and cannot be
recovered from its output. Nothing on the KDBX4 read path needs it, but it does
mean the class cannot honour all of `Credentials`. If you would rather split the
interface so the read path does not demand `getHash()`, say so and I will
restructure it before this is in a published API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
